### PR TITLE
Manually migrate to assimp 5.2.5

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,5 @@
 assimp:
-- 5.2.4
+- 5.2.5
 boost_cpp:
 - 1.78.0
 cdt_name:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 pin_run_as_build:

--- a/.ci_support/migrations/assimp525.yaml
+++ b/.ci_support/migrations/assimp525.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+assimp:
+- 5.2.5
+migrator_ts: 1663100710.2627342

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 assimp:
-- 5.2.4
+- 5.2.5
 boost_cpp:
 - 1.78.0
 channel_sources:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/fix_osx_deprecated.patch  # [osx]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin='x.x') }}


### PR DESCRIPTION
According to https://conda-forge.org/status/#assimp525, the migration to 5.2.5 is blocked by this package, with the message:
~~~
hpp-pinocchio (6) Error: not solvable ([bot CI job](https://github.com/regro/autotick-bot/actions/runs/3737744082)): main: ['linux_64_: Encountered problems while solving:\n - package hpp-fcl-1.8.1-py310hd26c143_0 requires assimp >=5.2.3,<5.2.4.0a0, but none of the providers can be installed\n', 'osx_64_: Encountered problems while solving:\n - package hpp-fcl-1.8.1-py310hd3398c4_0 requires assimp >=5.2.3,<5.2.4.0a0, but none of the providers can be installed\n']
Immediate Children: hpp-constraints, hpp-core, hpp-gepetto-viewer, hpp-manipulation, hpp-manipulation-corba, hpp-manipulation-urdf
~~~

even if the requires packages seems actually to be there.

So as an attempt to fix the migration was done manually according to the last part of https://conda-forge.org/docs/maintainer/knowledge_base.html#migrators-and-migrations .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
